### PR TITLE
更新已失效的连接

### DIFF
--- a/pcb/README.md
+++ b/pcb/README.md
@@ -3,7 +3,7 @@
 R饼锐度不够
 
 ## 嘉立创开源网址
-https://oshwhub.com/flanker-e/esp32s3-open-source-of-jue
+https://oshwhub.com/flanker-e/jue-zhi-tong-esp32
 
 ## 注意事项
 板子天线需要自己单独购买


### PR DESCRIPTION
之前 “R饼锐度不够” 制作pcd的连接失效了，更新了新的连接
( _https://oshwhub.com/flanker-e/esp32s3-open-source-of-jue_ -> _https://oshwhub.com/flanker-e/jue-zhi-tong-esp32_ )